### PR TITLE
different incus network for each container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 venv/
+.vscode/

--- a/usr/bin/incul-create-template
+++ b/usr/bin/incul-create-template
@@ -2,10 +2,17 @@
 
 echo -e "\n\e[1;33mSetup incul template...\e[0m"
 
+# Check if "def" is in the incus network list
+if ! incus network list | grep -q "def"; then
+    echo "Network 'def' does not exist. Please create it before proceeding."
+    incus network create def
+    incus network detach-profile incusbr0 default 
+fi
+
 # launch incus
 incus admin init --minimal
 
-incus launch images:debian/12 incul-template
+incus launch images:debian/12 incul-template --network def
 
 #copy files to container
 incus file push /etc/inculs-manager/config.sh incul-template/root/

--- a/usr/bin/incul-manager
+++ b/usr/bin/incul-manager
@@ -55,6 +55,7 @@ def delete(container_name):
 
     stop(container_name)
     subprocess.run(["incus", "delete", container_name])
+    subprocess.run(["incus", "network", "delete", f"net-{container_name}"])
 
     sync()
     restart_panel()

--- a/usr/bin/incul-manager
+++ b/usr/bin/incul-manager
@@ -11,7 +11,12 @@ import time
 # - append incul container .desktop files to host .desktop files
 def create(container_name):
     subprocess.run(["incus", "copy", "incul-template", container_name])
-
+    
+    # detach generic network and attach new network
+    subprocess.run(["incus", "network", "detach", "def", container_name])
+    subprocess.run(["incus", "network", "create", f"net-{container_name}"])
+    subprocess.run(["incus", "network", "attach", f"net-{container_name}", container_name])
+    
     start(container_name)
 
     # wait for container to start


### PR DESCRIPTION
This time I've kept the number of commit at the minimum.
The feature can be spitted in 3 part:
1) When the template is created, is attached to him a default network
2) At the creation of a container based on a template (like an office one), is create a network only for that specific container (net-office)
3) When the container is deleted, also the network is deleted.

About the remove of the network incusbr0 from the default profile, in my test, was impossible to remove the network from the container after creation,  so I opted to remove it from the profile.