### PR TITLE
Custom user and password for each container 

### DIFF
--- a/usr/bin/incul-init
+++ b/usr/bin/incul-init
@@ -25,6 +25,7 @@ sudo adduser "$CURRENT_USER" incus-admin
 mkdir -p /home/$USER/.local/share/applications
 mkdir -p /home/$USER/.local/share/desktop-directories
 mkdir -p /home/$USER/.config/menus
+mkdir -p /home/$USER/.config/incul-manager
 
 
 sudo cp -r /etc/inculs-manager/launcher-config/desktop-directories /home/$USER/.local/share/

--- a/usr/bin/incul-manager
+++ b/usr/bin/incul-manager
@@ -46,8 +46,11 @@ def new_user(container_name):
         subprocess.run(["incus", "file", "push", f"/home/{os.environ['USER']}/.config/incul-manager/{container_name}-config.sh", f"{container_name}/root/config.sh"])
         subprocess.run(["incus", "exec", container_name, "--", "chmod", "+x", "/root/config.sh"])
         subprocess.run(["incus", "exec", container_name, "--", "/root/incul-create-user"])
+        subprocess.run(["incus", "exec", container_name, "--","sudo", "deluser", "--remove-all-file", "incul"])
     else:
         print("Keeping the default user incul:incul")
+
+
 
 def start(container_name):
     subprocess.run(["incus", "start", container_name])

--- a/usr/bin/incul-manager
+++ b/usr/bin/incul-manager
@@ -1,16 +1,17 @@
 #!/usr/bin/python3
 
-
 import sys
 import subprocess
 import os
 import time
+import shutil
 
 # create  incul container
 # - create incul container
 # - append incul container .desktop files to host .desktop files
 def create(container_name):
     subprocess.run(["incus", "copy", "incul-template", container_name])
+    shutil.copy("/etc/inculs-manager/config.sh", f"/home/{os.environ['USER']}/.config/incul-manager/{container_name}-config.sh")
 
     start(container_name)
 
@@ -18,10 +19,35 @@ def create(container_name):
     # TODO: check for ip availability instead
     time.sleep(5)
 
+    new_user(container_name)
+
     sync()
 
     restart_panel()
 
+def new_user(container_name):
+    # Ask if the user wants a new username and password for this container
+    new_user = input("Do you want to create a new user for this container? (y/n): ").strip().lower()
+    if new_user == "y":
+        username = input("Enter the new username: ").strip()
+        password = input("Enter the new password: ").strip()
+        
+        with open(f"/home/{os.environ['USER']}/.config/incul-manager/{container_name}-config.sh", "r") as file:
+            config_lines = file.readlines()
+        with open(f"/home/{os.environ['USER']}/.config/incul-manager/{container_name}-config.sh", "w") as file:
+            for line in config_lines:
+                if line.startswith("username="):
+                    file.write(f'username="{username}"\n')
+                elif line.startswith("password="):
+                    file.write(f'password="{password}"\n')
+                else:
+                    file.write(line)
+                    
+        subprocess.run(["incus", "file", "push", f"/home/{os.environ['USER']}/.config/incul-manager/{container_name}-config.sh", f"{container_name}/root/config.sh"])
+        subprocess.run(["incus", "exec", container_name, "--", "chmod", "+x", "/root/config.sh"])
+        subprocess.run(["incus", "exec", container_name, "--", "/root/incul-create-user"])
+    else:
+        print("Keeping the default user incul:incul")
 
 def start(container_name):
     subprocess.run(["incus", "start", container_name])

--- a/usr/bin/incul-sync
+++ b/usr/bin/incul-sync
@@ -61,9 +61,14 @@ extract_global_inet_ip() {
 
 container_ip=$(incus info $container_name | extract_global_inet_ip)
 
-config_file="/etc/inculs-manager/config.sh"
+config_file="$HOME/.config/incul-manager/${container_name}-config.sh"
+# Check if the config file exists
+if [ ! -f "$config_file" ]; then
+	config_file="/etc/inculs-manager/config.sh"
+fi
 
 source "$config_file"
+
 
 # Array of colors with hex codes
 colors=(


### PR DESCRIPTION
I've decided to keep the default "incul" user for the template and implement the custom user only within the user's containers.

To make this work, when a new container is created, the `create` function generates a copy of the config.sh file in the `$HOME/.config/incul-manager` folder, with the updated value for user and password.
For this reason, also config_file in `usr/bin/incul-sync` is changed, with a fallback for containers (template) that not have their own configuration file.

NOTE: About  `sync,` at the moment for the templates I've insert the fallback to config.sh for avoid broken .desktop file, but if the idea is to keep them only as a base for avoid to recreate a full container each time, an idea could be complete remove the access to them from the desktop environment (so from xfce4 panel the user can access only to container create with the command `incul-manager create <container-name>`