### PR TITLE
Custom user for each container with ssh key

### DIFF
--- a/usr/bin/incul-init
+++ b/usr/bin/incul-init
@@ -27,6 +27,8 @@ mkdir -p /home/$USER/.local/share/desktop-directories
 mkdir -p /home/$USER/.config/menus
 mkdir -p /home/$USER/.config/incul-manager
 
+ssh-keygen -t rsa -b 4096 -C "$CURRENT_USER@incus-containers" -f "/home/$USER/.ssh/incul-id_rsa" -N ""
+echo "ssh-add /home/$USER/.ssh/incul-id_rsa > /dev/null 2>&1" >> /home/$USER/.bashrc 
 
 sudo cp -r /etc/inculs-manager/launcher-config/desktop-directories /home/$USER/.local/share/
 sudo cp /etc/inculs-manager/launcher-config/xfce-applications.menu /home/$USER/.config/menus
@@ -34,9 +36,6 @@ sudo cp /etc/inculs-manager/launcher-config/xfce-applications.menu /home/$USER/.
 echo -e "\n\e[1;33mIncul needs restart. This action requires confirmation. Press any key to continue...\e[0m"
 
 read -n 1 -s -r -p ""
-
-ssh-keygen -t rsa -b 4096 -C "$CURRENT_USER@incus-containers" -f "/home/$USER/.ssh/incul-id_rsa" -N ""
-ssh-add /home/$USER/.ssh/incul-id_rsa
 
 echo "Restarting the computer..."
 

--- a/usr/bin/incul-init
+++ b/usr/bin/incul-init
@@ -25,6 +25,7 @@ sudo adduser "$CURRENT_USER" incus-admin
 mkdir -p /home/$USER/.local/share/applications
 mkdir -p /home/$USER/.local/share/desktop-directories
 mkdir -p /home/$USER/.config/menus
+mkdir -p /home/$USER/.config/incul-manager
 
 
 sudo cp -r /etc/inculs-manager/launcher-config/desktop-directories /home/$USER/.local/share/
@@ -33,6 +34,9 @@ sudo cp /etc/inculs-manager/launcher-config/xfce-applications.menu /home/$USER/.
 echo -e "\n\e[1;33mIncul needs restart. This action requires confirmation. Press any key to continue...\e[0m"
 
 read -n 1 -s -r -p ""
+
+ssh-keygen -t rsa -b 4096 -C "$CURRENT_USER@incus-containers" -f "/home/$USER/.ssh/incul-id_rsa" -N ""
+ssh-add /home/$USER/.ssh/incul-id_rsa
 
 echo "Restarting the computer..."
 

--- a/usr/bin/incul-manager
+++ b/usr/bin/incul-manager
@@ -33,6 +33,7 @@ def new_user(container_name):
         username = input("Enter the new username: ").strip()
         password = input("Enter the new password: ").strip()
         
+        # Update the config file with the new username and password
         with open(f"/home/{os.environ['USER']}/.config/incul-manager/{container_name}-config.sh", "r") as file:
             config_lines = file.readlines()
         with open(f"/home/{os.environ['USER']}/.config/incul-manager/{container_name}-config.sh", "w") as file:
@@ -43,13 +44,47 @@ def new_user(container_name):
                     file.write(f'password="{password}"\n')
                 else:
                     file.write(line)
-                    
+        
+        # Push the updated config file to the container and delete the default user
         subprocess.run(["incus", "file", "push", f"/home/{os.environ['USER']}/.config/incul-manager/{container_name}-config.sh", f"{container_name}/root/config.sh"])
         subprocess.run(["incus", "exec", container_name, "--", "chmod", "+x", "/root/config.sh"])
         subprocess.run(["incus", "exec", container_name, "--", "/root/incul-create-user"])
         subprocess.run(["incus", "exec", container_name, "--","sudo", "deluser", "--remove-all-file", "incul"])
+        create_ssh_keys(container_name, username)
     else:
         print("Keeping the default user incul:incul")
+        create_ssh_keys(container_name, "incul")
+
+
+def create_ssh_keys(container_name, username):
+    ip_address = get_container_ip(container_name)
+    public_key = open(f"/home/{os.environ['USER']}/.ssh/incul-id_rsa.pub", "r").read()
+    
+    # Create the .ssh directory and add give correct permissions to the folder
+    subprocess.run(["incus", "exec", container_name, "--", "mkdir", "-p", f"/home/{username}/.ssh"])
+    subprocess.run(["incus", "exec", container_name, "--", "chown", "-R", f"{username}:{username}", f"/home/{username}/.ssh"])
+    subprocess.run(["incus", "exec", container_name, "--", "chmod", "700", f"/home/{username}/.ssh"])
+
+    # Add the public key to the authorized_keys file    
+    subprocess.run(["ssh-copy-id", "-i", f"/home/{os.environ['USER']}/.ssh/incul-id_rsa.pub", f"{username}@{ip_address}"])
+    
+    # Remove the password info from the config file
+    with open(f"/home/{os.environ['USER']}/.config/incul-manager/{container_name}-config.sh", "r") as file:
+            config_lines = file.readlines()
+    with open(f"/home/{os.environ['USER']}/.config/incul-manager/{container_name}-config.sh", "w") as file:
+        for line in config_lines:
+            if line.startswith("password="):
+                file.write(f'password=" "\n')
+            else:
+                file.write(line)
+
+def get_container_ip(container_name):
+    result = subprocess.run(
+        f"incus list | grep {container_name} | awk -F'|' '{{split($4, a, \"(\"); print a[1]}}'",
+        shell=True,
+        stdout=subprocess.PIPE
+    )
+    return result.stdout.decode("utf-8").strip().replace(" ", "")
 
 def start(container_name):
     subprocess.run(["incus", "start", container_name])

--- a/usr/bin/incul-manager
+++ b/usr/bin/incul-manager
@@ -5,23 +5,51 @@ import sys
 import subprocess
 import os
 import time
+import shutil
 
 # create  incul container
 # - create incul container
 # - append incul container .desktop files to host .desktop files
 def create(container_name):
     subprocess.run(["incus", "copy", "incul-template", container_name])
+    shutil.copy("/etc/inculs-manager/config.sh", f"/home/{os.environ['USER']}/.config/incul-manager/{container_name}-config.sh")
 
     start(container_name)
 
     # wait for container to start
     # TODO: check for ip availability instead
     time.sleep(5)
-
+    
+    new_user(container_name)
+    
     sync()
 
     restart_panel()
 
+def new_user(container_name):
+    # Ask if the user wants a new username and password for this container
+    new_user = input("Do you want to create a new user for this container? (y/n): ").strip().lower()
+    if new_user == "y":
+        username = input("Enter the new username: ").strip()
+        password = input("Enter the new password: ").strip()
+        
+        with open(f"/home/{os.environ['USER']}/.config/incul-manager/{container_name}-config.sh", "r") as file:
+            config_lines = file.readlines()
+        with open(f"/home/{os.environ['USER']}/.config/incul-manager/{container_name}-config.sh", "w") as file:
+            for line in config_lines:
+                if line.startswith("username="):
+                    file.write(f'username="{username}"\n')
+                elif line.startswith("password="):
+                    file.write(f'password="{password}"\n')
+                else:
+                    file.write(line)
+                    
+        subprocess.run(["incus", "file", "push", f"/home/{os.environ['USER']}/.config/incul-manager/{container_name}-config.sh", f"{container_name}/root/config.sh"])
+        subprocess.run(["incus", "exec", container_name, "--", "chmod", "+x", "/root/config.sh"])
+        subprocess.run(["incus", "exec", container_name, "--", "/root/incul-create-user"])
+        subprocess.run(["incus", "exec", container_name, "--","sudo", "deluser", "--remove-all-file", "incul"])
+    else:
+        print("Keeping the default user incul:incul")
 
 def start(container_name):
     subprocess.run(["incus", "start", container_name])

--- a/usr/bin/incul-manager
+++ b/usr/bin/incul-manager
@@ -24,7 +24,8 @@ def create(container_name):
     # TODO: check for ip availability instead
     time.sleep(5)
     
-    new_user(container_name)
+    user = new_user(container_name)
+    import_ssh_keys(container_name, user)
     
     sync()
 
@@ -54,15 +55,14 @@ def new_user(container_name):
         subprocess.run(["incus", "exec", container_name, "--", "chmod", "+x", "/root/config.sh"])
         subprocess.run(["incus", "exec", container_name, "--", "/root/incul-create-user"])
         subprocess.run(["incus", "exec", container_name, "--","sudo", "deluser", "--remove-all-file", "incul"])
-        create_ssh_keys(container_name, username)
+        return username
     else:
         print("Keeping the default user incul:incul")
-        create_ssh_keys(container_name, "incul")
+        return "incul"
 
 
-def create_ssh_keys(container_name, username):
+def import_ssh_keys(container_name, username):
     ip_address = get_container_ip(container_name)
-    public_key = open(f"/home/{os.environ['USER']}/.ssh/incul-id_rsa.pub", "r").read()
     
     # Create the .ssh directory and add give correct permissions to the folder
     subprocess.run(["incus", "exec", container_name, "--", "mkdir", "-p", f"/home/{username}/.ssh"])

--- a/usr/bin/incul-sync
+++ b/usr/bin/incul-sync
@@ -103,8 +103,14 @@ for file in "$folder_path"/*.desktop; do
 		# Extract arguments from existing Exec string, ignoring the exec keys %f %F %u %U %i %c %k
 		old_args=$(echo "$old_exec" | sed -E 's/(^| )%[fFuUiIcCkK]($| )//g')
 
+
+		# The template container not have an ssh key, so we need to login with password
+		if [[ "$container_name" == "incul-template" ]]; then
 		# Create the new Exec string
-		new_exec="Exec=bash -c 'xpra start ssh://$username:$password@$container_ip --title=\"${container_name^}: @title@\" --border=${colors[$index]},3 --exit-with-children --start-child=\"$old_args\"'"
+			new_exec="Exec=bash -c 'xpra start ssh://$username:$password@$container_ip --title=\"${container_name^}: @title@\" --border=${colors[$index]},3 --exit-with-children --start-child=\"$old_args\"'"
+		else
+			new_exec="Exec=bash -c 'xpra start ssh://$username@$container_ip --title=\"${container_name^}: @title@\" --border=${colors[$index]},3 --exit-with-children --start-child=\"$old_args\"'"
+		fi
 
 		# Replace the Exec string in the file
 		sed -i "s|^Exec=.*$|$new_exec|" "$file"

--- a/usr/bin/incul-sync
+++ b/usr/bin/incul-sync
@@ -61,7 +61,11 @@ extract_global_inet_ip() {
 
 container_ip=$(incus info $container_name | extract_global_inet_ip)
 
-config_file="/etc/inculs-manager/config.sh"
+config_file="$HOME/.config/incul-manager/${container_name}-config.sh"
+# Check if the config file exists
+if [ ! -f "$config_file" ]; then
+	config_file="/etc/inculs-manager/config.sh"
+fi
 
 source "$config_file"
 


### PR DESCRIPTION
The creation of the new user follows the same process as the pull request I previously closed. The main differences are:

- After the container is created, the password is removed from the configuration file saved on the host system.
- In the initialization script, an SSH key is generated to enable secure login to all containers. This ensures that `.desktop` files created by the `incul-manager sync` command do not contain hard-coded passwords. (The only exception at the moment is the template container.)
  - The generated SSH key is named `_incul-id_rsa_` to avoid conflicts with any existing `id_rsa` keys.
  - This key is added to the SSH agent using the command `ssh-add path/to/key`. Additionally, the command is added to the `.bashrc` file because the SSH agent resets with each system boot.
