### PR TITLE
Implemented input check for incul-manager actions 

### DIFF
--- a/usr/bin/incul-manager
+++ b/usr/bin/incul-manager
@@ -148,43 +148,14 @@ if __name__ == "__main__":
         )
         sys.exit(1)
 
-    if action == "list":
+    if action in ["list", "init", "sync"]:
         actions[action]()
 
-    if action == "init":
-        actions[action]()
-
-    if action == "sync":
-        actions[action]()
-
-    if action == "create":
+    if action in ["create", "start", "pause", "stop", "restart", "backup", "delete"]:
         arg_check(container_name)
         actions[action](container_name)
 
-    if action == "start":
-        arg_check(container_name)
-        actions[action](container_name)
-
-    if action == "pause":
-        arg_check(container_name)
-        actions[action](container_name)
-
-    if action == "stop":
-        arg_check(container_name)
-        actions[action](container_name)
-
-    if action == "restart":
-        arg_check(container_name)
-        actions[action](container_name)
-
-    if action == "backup":
-        arg_check(container_name)
-        actions[action](container_name)
-
-    if action == "delete":
-        arg_check(container_name)
-        actions[action](container_name)
-
+    # TODO: be able to create different templates
     if action == "create-template":
         actions[action]()
 

--- a/usr/bin/incul-manager
+++ b/usr/bin/incul-manager
@@ -115,7 +115,10 @@ def restart_panel():
     script_path = "restart-xfce4-panel"
     run_script(script_path)
 
-
+def arg_check(container_name):
+    if container_name is None:
+        print("Please provide a container name for this action.")
+        sys.exit(1)
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
@@ -155,24 +158,31 @@ if __name__ == "__main__":
         actions[action]()
 
     if action == "create":
+        arg_check(container_name)
         actions[action](container_name)
 
     if action == "start":
+        arg_check(container_name)
         actions[action](container_name)
 
     if action == "pause":
+        arg_check(container_name)
         actions[action](container_name)
 
     if action == "stop":
+        arg_check(container_name)
         actions[action](container_name)
 
     if action == "restart":
+        arg_check(container_name)
         actions[action](container_name)
 
     if action == "backup":
+        arg_check(container_name)
         actions[action](container_name)
 
     if action == "delete":
+        arg_check(container_name)
         actions[action](container_name)
 
     if action == "create-template":


### PR DESCRIPTION
 There is not much to say, I added a check of the argument passed to the incus command to avoid unintended behavior.
I also grouped the actions by the number of args required (I just kept create-template separate)