### PR TITLE
keep desired desktop entry keys fixes #10

### DIFF
--- a/build/debian/changelog
+++ b/build/debian/changelog
@@ -27,3 +27,11 @@ incul (2.0.0)
     - Added support for Debian 13 (Trixie).
 
  -- Muna Bedan <munabedan@gmail.com>  Mon, 13 Apr 2026 11:30:12 +0000
+
+incul (2.0.1)
+
+  * Bug fix: 
+    - updated sync to clean .desktop entries with sed to only keep required fields 
+      to avoid cluttering the host Open With context menu.
+
+ -- Muna Bedan <munabedan@gmail.com>  Wed, 06 May 2026 11:54:00 +0300

--- a/build/debian/control
+++ b/build/debian/control
@@ -1,5 +1,5 @@
 Package: incul
-Version: 2.0.0
+Version: 2.0.1
 Architecture: all
 Maintainer: Muna Bedan <munabedan@gmail.com>
 Description: Lightweight container-based desktop compartmentalization.

--- a/incul/incul-sync
+++ b/incul/incul-sync
@@ -142,11 +142,27 @@ folder_path="$app_path/$container_name"
 # Loop through the desktop entries in the container applications directory
 for file in "$folder_path"/*.desktop; do
     if [ -f "$file" ]; then
+        # Keep only the desired keys
+        sed -i -n "
+            1i[Desktop Entry]
+            /^Name=/p
+            /^Comment=/p
+            /^Exec=/p
+            /^Icon=/p
+            /^Terminal=/p
+            /^Type=/p
+            /^Categories=/p
+            /^Keywords=/p
+        " "$file"
+
         # Remove TryExec to prevent the menu from hiding the entry if the binary isn't local
         sed -i "/^TryExec=/d" "$file"
         
         # Update the Category value to be the container name
         sed -i "/^Categories=/s/$/${container_name^};Incul;/" "$file"
+
+        # Normalize Categories to only container + Incul
+        sed -i "s|^Categories=.*$|Categories=${container_name^};Incul;|" "$file"
 
         # Get the Exec line and clean the placeholders 
         old_exec=$(grep "^Exec=" "$file" | head -n1 | cut -d '=' -f2-)


### PR DESCRIPTION
This change fixes the issue I was having with the open with context menu by purging all the keys for each desktop entry leaving only:

```
[Desktop Entry]
Name=
Comment=
Exec=
Icon=
Terminal=
Type=
Categories=
Keywords=
```